### PR TITLE
Sort results by prefix match

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: "riffyn:autocomplete",
   summary: "Client/server autocompletion designed for Meteor's collections and reactivity",
-  version: "0.4.11",
+  version: "0.4.12",
   git: "https://github.com/mizzao/meteor-autocomplete.git"
 });
 
@@ -21,7 +21,7 @@ Package.onUse(function (api) {
     'autocomplete-client.coffee',
     'templates.coffee'
   ], 'client');
-  
+
   api.addFiles([
     'autocomplete-server.coffee'
   ], 'server');

--- a/templates.coffee
+++ b/templates.coffee
@@ -47,6 +47,8 @@ Template._autocompleteContainer.events
   "mouseenter .-autocomplete-item": (e, t) -> t.data.onItemHover(this, e)
 
 Template._autocompleteContainer.helpers
-  empty: -> @filteredList().count() is 0
+  empty: ->
+    filteredList = @filteredList()
+    if filteredList.length? then filteredList.length is 0 else filteredList.count() is 0
   footerTemplate: -> @matchedRule().footerTemplate || false
   noMatchTemplate: -> @matchedRule().noMatchTemplate || Template._noMatch


### PR DESCRIPTION
* Provides a flag autocompleteSort to sort results like an autocomplete. First results are
  sorted by whether they start with the entered query. The matching subset are sorted by
  length. The remaining results are appended to the end, up to the given limit.

**Must also update Unity to take effect.**

Closes RiffynInc/unity#681
See also pull request RiffynInc/unity#757
@lnader @tgardner4 