### PR TITLE
Add autocompleteSort function

### DIFF
--- a/autocomplete-client.coffee
+++ b/autocomplete-client.coffee
@@ -233,21 +233,27 @@ class @AutoComplete
     if isServerSearch(rule)
       if rule.autocompleteSort
         hits = AutoCompleteRecords.find({}, options).fetch()
-
-        # Return the results that start with the query string first, sorted by length
         val = @getText()
-        typeaheadResults = _.filter( hits, (hit) -> hit.name.search( "^#{val}.*" ) > -1 )
-        typeaheadResults = _.sortBy( typeaheadResults, (hit) -> return hit.name.length )
-        otherResults = _.filter( hits, (hit) -> return hit not in typeaheadResults )
-
-        # Then append the remaining results
-        sortedResults = typeaheadResults.concat( otherResults )
-        return sortedResults
+        return @autocompleteSort(hits, val)
       else
         return AutoCompleteRecords.find({}, options)
 
     # Otherwise, search on client
-    return rule.collection.find(selector, options)
+    if rule.autocompleteSort
+      hits = rule.collection.find(selector, options).fetch()
+      val = @getText()
+      return @autocompleteSort(hits, val)
+    else
+      return rule.collection.find(selector, options)
+
+  autocompleteSort: (hits, query_string) ->
+      # Return the results that start with the query string first, sorted by length
+    typeaheadResults = _.filter( hits, (hit) -> hit.name.search( "^#{query_string}.*" ) > -1 )
+    typeaheadResults = _.sortBy( typeaheadResults, (hit) -> return hit.name.length )
+    otherResults = _.filter( hits, (hit) -> return hit not in typeaheadResults )
+
+    # Then append the remaining results
+    return typeaheadResults.concat( otherResults )
 
   isShowing: ->
     rule = @matchedRule()

--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: "riffyn:autocomplete",
   summary: "Client/server autocompletion designed for Meteor's collections and reactivity",
-  version: "0.4.12",
+  version: "0.4.13",
   git: "https://github.com/mizzao/meteor-autocomplete.git"
 });
 


### PR DESCRIPTION
@lnader To address [unity issue #805](https://github.com/RiffynInc/unity/issues/805) without resorting to Elasticsearch. Paired with [unity PR #1014](https://github.com/RiffynInc/unity/pull/1014).

* Allows any autocomplete search to be sorted by result length instead of alphabetically.
  Works for client-based and server-based searches. Because there are so many similar
  terms in the database, sorting alphabetically leaves short, logical results off of the screen.
  This was the case with units, in particular.