### PR TITLE
Use synonyms + units + names for autocompleteSort

### DIFF
--- a/autocomplete-client.coffee
+++ b/autocomplete-client.coffee
@@ -240,16 +240,35 @@ class @AutoComplete
 
     # Otherwise, search on client
     if rule.autocompleteSort
+      # Need to get back a lot of results to capture all prefix matches
+      limit = options.limit
+      options.limit = 50
       hits = rule.collection.find(selector, options).fetch()
       val = @getText()
-      return @autocompleteSort(hits, val)
+      return @autocompleteSort(hits, val).slice(0, limit)
     else
       return rule.collection.find(selector, options)
 
   autocompleteSort: (hits, query_string) ->
-      # Return the results that start with the query string first, sorted by length
-    typeaheadResults = _.filter( hits, (hit) -> hit.name.search( "^#{query_string}.*" ) > -1 )
-    typeaheadResults = _.sortBy( typeaheadResults, (hit) -> return hit.name.length )
+    # Return the results that start with the query string first, sorted by length
+    # All typeahead results on name come first, then all synonyms, finally all
+    # symbols. BUT, a full-string match to a name or synonym is put first.
+    typeaheadResults = _.filter( hits, (hit) ->
+      return hit.name.search( "^#{query_string}.*" ) > -1 or
+        _.any(hit.synonyms, (syn) -> syn.search( "^#{query_string}.*" ) > -1) or
+        hit.symbol?.search( "^#{query_string}.*" ) > -1
+    )
+    typeaheadResults = _.sortBy( typeaheadResults, (hit) ->
+      if query_string is hit.name or _.any(hit.synonyms, (syn) -> query_string is syn)
+        return 0
+      if hit.name.search( "^#{query_string}.*" ) > -1
+        return hit.name.length
+      else if _.any(hit.synonyms, (syn) -> syn.search( "^#{query_string}.*" ) > -1)
+        matchingSynonym = _.find(hit.synonyms, (syn) -> syn.search( "^#{query_string}.*" ) > -1)
+        return matchingSynonym.length + 100
+      else
+        return hit.symbol?.length + 200
+    )
     otherResults = _.filter( hits, (hit) -> return hit not in typeaheadResults )
 
     # Then append the remaining results

--- a/package.js
+++ b/package.js
@@ -1,12 +1,12 @@
 Package.describe({
   name: "riffyn:autocomplete",
   summary: "Client/server autocompletion designed for Meteor's collections and reactivity",
-  version: "0.4.14",
-  git: "https://github.com/mizzao/meteor-autocomplete.git"
+  version: "0.4.15",
+  git: "https://github.com/RiffynInc/meteor-autocomplete.git"
 });
 
 Package.onUse(function (api) {
-  api.versionsFrom("1.2");
+  api.versionsFrom("1.2.0.2");
 
   api.use(['blaze', 'templating', 'jquery'], 'client');
   api.use(['coffeescript', 'underscore']); // both


### PR DESCRIPTION
@lnader 

Fixes RiffynInc/unity#805
* Returns more results for autocomplete sort.
* Sorts results on length of matching field (name, synonym, or symbol [when available]),
  but gives name results first, then synonyms, then symbols.
* An exact match on name or synonym is promoted to the top of the results.
* Specifies Meteor 1.2.0.2
* Increments minor version
* Corrects git URL